### PR TITLE
fix(storage): load access_token in GetSession (sync broken in database mode)

### DIFF
--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -927,13 +927,13 @@ func (d *DatabaseStorage) GetSession(ctx context.Context, sessionID string) (*mo
 	var session models.Session
 
 	err := d.pool.QueryRow(ctx, `
-		SELECT u.id, u.github_id, u.login, u.name, u.email, u.avatar_url,
+		SELECT u.id, u.github_id, u.login, u.name, u.email, u.avatar_url, u.access_token, u.token_expires_at,
 		       s.id, s.user_id, s.expires_at, s.created_at
 		FROM sessions s
 		JOIN users u ON s.user_id = u.id
 		WHERE s.id = $1 AND s.expires_at > NOW()
 	`, sessionID).Scan(
-		&user.ID, &user.GitHubID, &user.Login, &user.Name, &user.Email, &user.AvatarURL,
+		&user.ID, &user.GitHubID, &user.Login, &user.Name, &user.Email, &user.AvatarURL, &user.AccessToken, &user.TokenExpiresAt,
 		&session.ID, &session.UserID, &session.ExpiresAt, &session.CreatedAt,
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

In `STORAGE_MODE=database`, repository sync (and any token-backed endpoint behind `AuthMiddleware`) fails with `oauth2: token expired and refresh token is not set`.

## Cause

`DatabaseStorage.GetSession` did not select `access_token`, so `user.AccessToken` was empty for every session-authenticated request. `SyncRepositories` then used an empty-token `oauth2.Token`, whose `Valid()` is false, so the oauth2 transport tries a refresh it cannot perform.

Memory storage is unaffected (the in-memory user keeps its token), which is why this only appears in database mode.

## Fix

Select `access_token` and `token_expires_at` in the `GetSession` join and scan them into the returned `User`.

Fixes #211

## Testing

- `go build ./...` passes.
- Manual (database mode): repository sync now retrieves repositories instead of failing with the oauth2 error.
