### PR TITLE
fix(storage): make workflow run/job upserts work on TimescaleDB hypertables

### DIFF
--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -730,7 +730,7 @@ func (d *DatabaseStorage) UpsertRun(ctx context.Context, run *models.WorkflowRun
 			event, branch, commit_sha, commit_message, actor_login, actor_avatar,
 			html_url, started_at, completed_at, duration_seconds, commit_timestamp, is_deployment, environment
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-		ON CONFLICT (github_id) DO UPDATE SET
+		ON CONFLICT (github_id, started_at) DO UPDATE SET
 			status = EXCLUDED.status,
 			conclusion = EXCLUDED.conclusion,
 			completed_at = EXCLUDED.completed_at,
@@ -799,7 +799,7 @@ func (d *DatabaseStorage) UpsertJob(ctx context.Context, job *models.WorkflowJob
 			github_id, run_id, run_github_id, name, status, conclusion, runner_name, runner_group,
 			labels, steps, started_at, completed_at, duration_seconds
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-		ON CONFLICT (github_id) DO UPDATE SET
+		ON CONFLICT (github_id, started_at) DO UPDATE SET
 			status = EXCLUDED.status,
 			conclusion = EXCLUDED.conclusion,
 			completed_at = EXCLUDED.completed_at,
@@ -1322,6 +1322,9 @@ SELECT create_hypertable('workflow_runs', 'started_at', if_not_exists => TRUE);
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id ON workflow_runs(workflow_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_repo_id ON workflow_runs(repo_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_github_id ON workflow_runs(github_id);
+-- Unique index for upsert: on a hypertable the unique columns must include the
+-- partitioning column (started_at). Matches ON CONFLICT (github_id, started_at).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_workflow_runs_github_id ON workflow_runs(github_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_status ON workflow_runs(status, started_at DESC);
 
 -- Workflow jobs table (TimescaleDB hypertable)
@@ -1349,6 +1352,8 @@ SELECT create_hypertable('workflow_jobs', 'started_at', if_not_exists => TRUE);
 
 CREATE INDEX IF NOT EXISTS idx_workflow_jobs_run_id ON workflow_jobs(run_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_workflow_jobs_github_id ON workflow_jobs(github_id);
+-- Unique index for upsert (hypertable: must include partitioning column started_at).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_workflow_jobs_github_id ON workflow_jobs(github_id, started_at);
 
 -- Deployments table
 CREATE TABLE IF NOT EXISTS deployments (


### PR DESCRIPTION
## Problem

In `STORAGE_MODE=database`, sync persists zero workflow runs/jobs:

```
Failed to save workflow run error="ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification"
```

## Cause

`workflow_runs` and `workflow_jobs` are hypertables with `PRIMARY KEY (id, started_at)` and a non-unique `github_id` (a hypertable unique index must include the partitioning column). `UpsertRun`/`UpsertJob` use `ON CONFLICT (github_id)`, which has no matching unique constraint, so every insert fails. Memory mode is unaffected (no SQL upsert).

## Fix

- Add `UNIQUE INDEX (github_id, started_at)` to both hypertables in the migration.
- Change both upserts to `ON CONFLICT (github_id, started_at)`.

`started_at` is stable for a given run/job, so the conflict target still dedupes correctly on re-sync.

Fixes #213

## Testing

- `go build ./...` passes.
- Manual (database mode): after the migration adds the unique indexes, sync persists runs/jobs (`runs > 0`) and the dashboard populates; the `ON CONFLICT` error is gone.
