### PR TITLE
fix: Add avgDuration handling to trend data retrieval

### DIFF
--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -1201,12 +1201,14 @@ func (d *DatabaseStorage) GetTrends(ctx context.Context, days int) ([]models.Tre
 	var trends []models.Trend
 	for rows.Next() {
 		var trend models.Trend
+		var avgDuration sql.NullFloat64
 		if err := rows.Scan(
 			&trend.Date, &trend.TotalRuns, &trend.SuccessfulRuns,
-			&trend.FailedRuns, &trend.AvgDuration, &trend.DeploymentCount,
+			&trend.FailedRuns, &avgDuration, &trend.DeploymentCount,
 		); err != nil {
 			return nil, err
 		}
+		trend.AvgDuration = int(avgDuration.Float64)
 		trends = append(trends, trend)
 	}
 


### PR DESCRIPTION
Running with STORAGE_MODE=database against Postgres/TimescaleDB, the dashboard
trends chart failed and the endpoint returns a 500 for me on a large org estate (Was testing out your project, I like it). The handler didn't log any specific error but when I looked into it, it looked like GetTrends `AVG(duration_seconds)` was coming back as numeric and being scanned straight into `Trend.AvgDuration` which is an int, causing a pgx rejection. 

`ListWorkflows` and `GetWorkflow` run the same aggregate but scan into `sql.NullFloat64` so I just followed their lead and applied the same change. 